### PR TITLE
add support for local archives containing shared libraries

### DIFF
--- a/etc/cget/cget.sh
+++ b/etc/cget/cget.sh
@@ -231,8 +231,10 @@ parse_package() {
 		parse_cmdline $args
 		unset args url
 		[ ! -f requirements.txt ] || pkg_depends="$PWD/requirements.txt"
-	elif [ -e "$pkg_url" ]; then
+	elif [ -d "$pkg_url" ]; then
 		pkg_url="$(abs "$pkg_url")"
+	elif [ -e "$pkg_url" ]; then
+		pkg_url="file:///$(abs "$pkg_url")"
 	else
 		case "$pkg_url" in
 			http://*|https://*|ftp://*) ;;

--- a/etc/package-dynamic.sh
+++ b/etc/package-dynamic.sh
@@ -69,6 +69,7 @@ copy_libs() {
 		[ "$type" = "NEEDED" ] || continue
 		[ ! -f "$bindir/$lib" ] || continue
 		find "$toolchain" -name "$lib" -exec cp {} "$bindir/" ';'
+		find "$bindir/../../../lib" -name "$lib" -exec cp {} "$bindir/" ';'
 		copy_libs "$bindir/$lib"
 	done
 }


### PR DESCRIPTION
This is a small change that allows recipes to contain source archives directly, for local packages with no HTTP download location (e.g. in-house binary-only libs). It also fixes the dynamic linking packager to package such locally installed shared libraries, if they exist.